### PR TITLE
Removed carriage return from markdown attachment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ server.post('/api/messages/', (req, res) => {
         });
 
         value && attachments.push({
-          content: `\`\`\`\r\n${ JSON.stringify(value, null, 2) }\r\n\`\`\``,
+          content: `\`\`\`\n${ JSON.stringify(value, null, 2) }\n\`\`\``,
           contentType: 'text/markdown'
         });
 


### PR DESCRIPTION
Web Chat's default markdown renderer - Markdown-it - does not respect CRLF carriage returns, so each time MockBot uses a CRLF carriage return, Web Chat renders it as a newline character instead.

At the moment, MockBot is sending markdown code attachments with CRLF carriage return, but since Web Chat treats them as newline characters, they are displaying without the extra white space. However, when Web Chat updates the markdown renderer to properly handle CRLF carriage returns, the markdown attachments will render with extra whitespace. 

```javascript
renderMarkdown(`\`\`\`\r\n${ JSON.stringify({ hello: "World!" }, null, 2) }\r\n\`\`\``)
```

#### Expected

![suggested-actions-js-suggested-actions-command-should-show-response-from-bot-and-text-from-user-on-messageback-1-diff](https://user-images.githubusercontent.com/17039790/58965151-f5184a80-8764-11e9-99a6-1017a6fb326f.png)


```html
<pre><code>{
  "hello": "World!";
}
</code></pre>
```

#### Actual - after renderer update

![suggested-actions-js-suggested-actions-command-should-show-response-from-bot-and-text-from-user-on-messageback-1-diff-2](https://user-images.githubusercontent.com/17039790/58965173-fea1b280-8764-11e9-83b8-c73c7019f05b.png)

```html
<pre><code>
{
  "hello": "World!"
}


</code></pre>
```

#### Fix

To resolve this issue, we can change the CRLF carriage returns to newline characters since Web Chat is already treating carriage returns as newline characters.
