### PR TITLE
Added markdown features to hero card command

### DIFF
--- a/src/commands/HeroCard.ts
+++ b/src/commands/HeroCard.ts
@@ -56,8 +56,12 @@ async function processor(context: TurnContext) {
           value: `${ PUBLIC_URL }testurl2.html`
         },
         subtitle: 'This is the subtitle',
-        text: 'Price: $XXX.XX USD',
-        title: 'Details about image 1',
+        text: '**Price: $XXX.XX USD**\r\n------\n Additional details\r\n' +
+
+        '1. List item 1 \n' +
+        '2. List item 2 \n' +
+        '3. List item 3',
+        title: '[Details about image 1](https://microsoft.com)',
       }
     }],
   });


### PR DESCRIPTION
Added markdown features to hero card command for testing rich cards with markdown in Web Chat. This change does not interfere with any other Web Chat tests. 

![image](https://user-images.githubusercontent.com/17039790/59135626-8a1d6e00-8934-11e9-8795-b11a04dfd037.png)
