### PR TITLE
Removed welcome message from conversation update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -320,13 +320,7 @@ server.post('/api/messages', (req, res) => {
 
     numActivities++;
 
-    // On "conversationUpdate"-type activities this bot will send a greeting message to users joining the conversation.
-    if (
-      context.activity.type === 'conversationUpdate'
-      && (context.activity.membersAdded || []).some(({ id }) => id !== context.activity.recipient.id)
-    ) {
-      await context.sendActivity(`Welcome to Mockbot v4!`);
-    } else if (context.activity.type === 'event') {
+    if (context.activity.type === 'event') {
       if (context.activity.name === 'tokens/response') {
         // Special handling for OAuth token exchange
         // This event is sent thru the non-magic code flow


### PR DESCRIPTION
The new changes to the Direct Line Connector service causes the first Conversation Update Event to include the user id along with the bot id if the token used to create the conversation contained a user id. Consequently, this causes the welcome message in MockBot to send before the user messages the bot and is causing a majority of the Web Chat tests to fail. I simply removed the code responsible for sending the welcome message to resolve this issue. 

<img width="449" alt="Untitled" src="https://user-images.githubusercontent.com/17039790/61013148-5ae48d00-a336-11e9-9a28-e508ac8e5c91.png">

