### PR TITLE
Added messageReaction activity handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -342,7 +342,6 @@ server.post('/api/messages', (req, res) => {
         type: 'message',
         attachments
       });
-
     } else if (context.activity.type === 'message') {
       const { activity: { attachments = [], text } } = context;
       const cleanedText = (text || '').trim().replace(/\.$/, '');

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,6 +330,19 @@ server.post('/api/messages', (req, res) => {
       } else if (context.activity.name === 'webchat/ping') {
         await context.sendActivity({ type: 'event', name: 'webchat/pong', value: context.activity.value });
       }
+    } else if (context.activity.type === 'messageReaction') {
+      const { activity: { reactionsAdded = [], reactionsRemoved = [] }} = context;
+      const attachments = [...reactionsAdded, ...reactionsRemoved].map(reaction => ({
+        content: `\`\`\`\n${ JSON.stringify(reaction, null, 2) }\n\`\`\``,
+        contentType: 'text/markdown'
+      }));
+
+      await context.sendActivity({
+        text: 'You posted',
+        type: 'message',
+        attachments
+      });
+
     } else if (context.activity.type === 'message') {
       const { activity: { attachments = [], text } } = context;
       const cleanedText = (text || '').trim().replace(/\.$/, '');


### PR DESCRIPTION
Added a `messageReaction` activity handler to Mock Bot so the reaction buttons sample could be updated to use the  `messageReaction` activity type that was introduced in the Bot Framework SDK in v4.5.

https://github.com/microsoft/BotFramework-WebChat/issues/2229